### PR TITLE
Calling MacOS.xcode_version is deprecated!

### DIFF
--- a/rtlsdr.rb
+++ b/rtlsdr.rb
@@ -11,7 +11,7 @@ class Rtlsdr < Formula
   depends_on 'cmake' => :build
   depends_on 'libusb'
 
-  if MacOS.xcode_version.to_f >= 4.3
+  if MacOS::Xcode.version.to_f >= 4.3
     depends_on 'autoconf'
   end
 


### PR DESCRIPTION
Use MacOS::Xcode.version instead.